### PR TITLE
Add conditional signing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ artifacts {
 
 signing {
     // requires gradle.properties, see http://www.gradle.org/docs/current/userguide/signing_plugin.html
+    required { gradle.taskGraph.hasTask("uploadArchives") }
     sign configurations.archives
 }
 
@@ -57,10 +58,10 @@ uploadArchives {
 
             repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
                 // username and password from gradle.properties
-                authentication(userName: sonatypeUsername, password: sonatypePassword)
+                authentication(userName: { sonatypeUsername }, password: { sonatypePassword } )
             }
             snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: sonatypeUsername, password: sonatypePassword)
+                authentication(userName: { sonatypeUsername }, password: { sonatypePassword })
             }
 
             pom.project {


### PR DESCRIPTION
Changed two things:
1) signing will be skipped if uploadArchives is not in TaskGraph (note the curly brakets)
2) sonatypeUsername & sonatypePassword are only needed when the sonatype Repository is used for uploading

I checked locally and I can execute the build task and signArchives is being skipped. I do not have a gradle.properties file. I could not check if uploading still works, since I have no sonatype access. But the properties should be evaluated at execution time and not at configuration time, so it should be fine.
