### PR TITLE
Show all parameters for method using DataProvider

### DIFF
--- a/src/main/java/com/tngtech/java/junit/dataprovider/DataProviderFrameworkMethod.java
+++ b/src/main/java/com/tngtech/java/junit/dataprovider/DataProviderFrameworkMethod.java
@@ -42,7 +42,7 @@ public class DataProviderFrameworkMethod extends FrameworkMethod {
     public String getName() {
         // don't print last value, if is the expected one
         return String.format("%s [%d: %s]", super.getName(), idx,
-                formatParameters(Arrays.copyOf(parameters, parameters.length == 1 ? 1 : parameters.length - 1)));
+                formatParameters(parameters));
     }
 
     @Override

--- a/src/test/java/com/tngtech/java/junit/dataprovider/DataProviderFrameworkMethodTest.java
+++ b/src/test/java/com/tngtech/java/junit/dataprovider/DataProviderFrameworkMethodTest.java
@@ -48,7 +48,7 @@ public class DataProviderFrameworkMethodTest {
     }
 
     @Test
-    public void testGetNameShouldRemoveLastValueFromParametersStringIfMoreThanOneParameterIsGiven() {
+    public void testGetNameShouldShowAllParametersFromParametersString() {
 
         // Given:
         Method method = anyMethod();
@@ -60,7 +60,7 @@ public class DataProviderFrameworkMethodTest {
         String result = underTest.getName();
 
         // Then:
-        assertThat(result).matches(method.getName() + " \\[1: 1024, 32\\]");
+        assertThat(result).matches(method.getName() + " \\[1: 1024, 32, 128\\]");
     }
 
     @Test


### PR DESCRIPTION
It is really confusing not to see all parameters of a test using a DataProvider. Please show them all. If this is not desirable from your perspective then at least make it configurable.
