### PR TITLE
Use in-memory keys for signing.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -519,6 +519,9 @@ subprojects {
     // requires gradle.properties, see http://www.gradle.org/docs/current/userguide/signing_plugin.html
     configure<SigningExtension> {
         setRequired({ isReleaseVersion && gradle.taskGraph.hasTask("publish") })
+        val signingKey: String? by project
+        val signingPassword: String? by project
+        useInMemoryPgpKeys(signingKey, signingPassword)
         sign(the<PublishingExtension>().publications["mavenJava"])
     }
 }


### PR DESCRIPTION
*This allows to provide password and key via project properties instead having to use gradle.properties

Signed-off-by: Nils-Oliver Linden

## Overview

Provide password and key for signing via project properties instead of gradle.properties

---

I hereby agree to the terms of the [JUnit dataprovider Contributor License Agreement](https://github.com/tng/junit-dataprovider/blob/master/CONTRIBUTING.md#junit-dataprovider-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://github.com/TNG/junit-dataprovider/blob/master/core/src/main/java/com/tngtech/junit/dataprovider/Preconditions.java) are checked and documented in the method's Javadoc
- [x] Change is covered by automated tests (unit and/or integration tests)
- [x] [Build](https://travis-ci.org/TNG/junit-dataprovider) has passed
