### PR TITLE
Allow running of individual test methods via Gradle in conjunction with junit-vintage-runner

### DIFF
--- a/junit4/src/main/java/com/tngtech/java/junit/dataprovider/DataProviderFilter.java
+++ b/junit4/src/main/java/com/tngtech/java/junit/dataprovider/DataProviderFilter.java
@@ -78,7 +78,7 @@ public class DataProviderFilter extends Filter {
         String filterDescription = filter.describe();
 
         Matcher filterDescriptionMatcher = DESCRIPTION_PATTERN.matcher(filterDescription);
-        if (filterDescription.contains(" OR ") || !filterDescriptionMatcher.find()) {
+        if (filterDescription.contains(" OR ") || filterDescription.contains("exclude ") || !filterDescriptionMatcher.find()) {
             return filter.shouldRun(description);
         }
         String methodName = filterDescriptionMatcher.group(GROUP_METHOD_NAME);

--- a/junit4/src/test/java/com/tngtech/java/junit/dataprovider/DataProviderFilterTest.java
+++ b/junit4/src/test/java/com/tngtech/java/junit/dataprovider/DataProviderFilterTest.java
@@ -87,6 +87,21 @@ public class DataProviderFilterTest extends BaseTest {
     }
 
     @Test
+    public void testShouldRunShouldCallOriginalFilterShouldRunIfGivenDescriptionContainsExclude() {
+        // Given:
+        when(filter.describe()).thenReturn("exclude Method failing1[0: 0](Test1)");
+        Description description = setupDescription(true, "failing1[0: 0](Test1)");
+
+        // When:
+        underTest.shouldRun(description);
+
+        // Then:
+        verify(filter).describe();
+        verify(filter).shouldRun(description);
+        verifyNoMoreInteractions(filter);
+    }
+
+    @Test
     public void testShouldRunShouldReturnFalseWhenDescriptionDoesNotHaveExpectedMethodName() {
         // Given:
         when(filter.describe()).thenReturn("Method testMain[1: ](com.tngtech.Clazz)");


### PR DESCRIPTION
## Overview

Gradle creates org.junit.vintage.engine.descriptor.RunnerTestDescriptor.
ExcludeDescriptionFilters when running individual test methods. The
filter description starts with "exclude " and for those filters, the
request needs to be forwarded to the original `filter.shouldRun(...)`,
as otherwise the DataProvider would run this test even if it should not.

---

I hereby agree to the terms of the [JUnit dataprovider Contributor License Agreement](https://github.com/tng/junit-dataprovider/blob/master/CONTRIBUTING.md#junit-dataprovider-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://github.com/TNG/junit-dataprovider/blob/master/core/src/main/java/com/tngtech/junit/dataprovider/Preconditions.java) are checked and documented in the method's Javadoc
- [x] Change is covered by automated tests (unit and/or integration tests)
- [x] [Build](https://travis-ci.org/TNG/junit-dataprovider) has passed
