### PR TITLE
Fix NoClassDefFoundError with JUnit 5.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,9 @@ build-job: &build-job
                 # Restart caching for every new wrapper and add job name (= JDK version) as JDK influences Gradle's caching
                 - gradle-repo-v2-{{ .Environment.CIRCLE_JOB }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
 
-        - run: ./gradlew --build-cache --scan build -Pjunit4Version=4.10  -PjunitJupiterVersion=5.5.0 -PskipSpotBugs
-        - run: ./gradlew --build-cache --scan build -Pjunit4Version=4.11  -PjunitJupiterVersion=5.5.2 -PskipSpotBugs
-        - run: ./gradlew --build-cache --scan build -Pjunit4Version=4.12  -PjunitJupiterVersion=5.6.3 -PskipSpotBugs
+        - run: ./gradlew --build-cache --scan build -Pjunit4Version=4.10  -PjunitJupiterVersion=5.9.0 -PskipSpotBugs
+        - run: ./gradlew --build-cache --scan build -Pjunit4Version=4.11  -PjunitJupiterVersion=5.9.0 -PskipSpotBugs
+        - run: ./gradlew --build-cache --scan build -Pjunit4Version=4.12  -PjunitJupiterVersion=5.9.0 -PskipSpotBugs
         - run: ./gradlew --build-cache --scan build
         - run: COVERALLS_REPO_TOKEN=Npp4tyTSCz0wSMZTJ81vXdVe1uw6WtRrC ./gradlew --build-cache --scan jacocoRootReport coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ jdk:
   - oraclejdk11
 
 script:
-  - ./gradlew --scan build -Pjunit4Version=4.10  -PjunitJupiterVersion=5.5.0 -PskipSpotBugs
-  - ./gradlew --scan build -Pjunit4Version=4.11  -PjunitJupiterVersion=5.5.2 -PskipSpotBugs
-  - ./gradlew --scan build -Pjunit4Version=4.12  -PjunitJupiterVersion=5.6.3 -PskipSpotBugs
+  - ./gradlew --scan build -Pjunit4Version=4.10  -PjunitJupiterVersion=5.9.0 -PskipSpotBugs
+  - ./gradlew --scan build -Pjunit4Version=4.11  -PjunitJupiterVersion=5.9.0 -PskipSpotBugs
+  - ./gradlew --scan build -Pjunit4Version=4.12  -PjunitJupiterVersion=5.9.0 -PskipSpotBugs
   - ./gradlew --scan build
 
   - cd ${TRAVIS_BUILD_DIR}/junit4/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ println("Using skipSpotBugs = $skipSpotBugs for current build.")
 // set default junit versions if not set via command line
 val junit4Version by extra(findProperty("junit4Version")?.toString() ?: "4.13.1")
 println("Using JUnit4 version $junit4Version for current build.")
-val junitJupiterVersion by extra(findProperty("junitJupiterVersion")?.toString() ?: "5.7.0")
+val junitJupiterVersion by extra(findProperty("junitJupiterVersion")?.toString() ?: "5.9.0")
 println("Using JUnit Jupiter version $junitJupiterVersion for current build.")
 
 class Dependency {

--- a/junit-jupiter-params/pom.xml
+++ b/junit-jupiter-params/pom.xml
@@ -70,12 +70,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.5.0</version>
+            <version>5.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.5.0</version>
+            <version>5.9.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/junit-jupiter-params/src/main/java/com/tngtech/junit/dataprovider/AbstractUseDataProviderArgumentProvider.java
+++ b/junit-jupiter-params/src/main/java/com/tngtech/junit/dataprovider/AbstractUseDataProviderArgumentProvider.java
@@ -173,6 +173,7 @@ public abstract class AbstractUseDataProviderArgumentProvider<SOURCE_ANNOTATION 
 
     private ConfigurationParameters emptyConfigurationParameters() {
         return new ConfigurationParameters() {
+            @SuppressWarnings("deprecation")
             @Override
             public int size() {
                 return 0;

--- a/junit-jupiter-params/src/main/java/com/tngtech/junit/dataprovider/AbstractUseDataProviderArgumentProvider.java
+++ b/junit-jupiter-params/src/main/java/com/tngtech/junit/dataprovider/AbstractUseDataProviderArgumentProvider.java
@@ -30,10 +30,9 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
-import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.engine.config.DefaultJupiterConfiguration;
-import org.junit.jupiter.engine.execution.InterceptingExecutableInvoker;
+import org.junit.jupiter.engine.execution.DefaultExecutableInvoker;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.platform.engine.ConfigurationParameters;
@@ -53,8 +52,6 @@ import com.tngtech.junit.dataprovider.resolver.DataProviderResolverContext;
  */
 public abstract class AbstractUseDataProviderArgumentProvider<SOURCE_ANNOTATION extends Annotation, DATAPROVIDER_ANNOTATION extends Annotation>
         extends AbstractDataProviderArgumentProvider<SOURCE_ANNOTATION> {
-
-    private static final InterceptingExecutableInvoker executableInvoker = new InterceptingExecutableInvoker();
 
     protected static final Namespace NAMESPACE_USE_DATAPROVIDER = Namespace
             .create(AbstractUseDataProviderArgumentProvider.class, "dataCache");
@@ -156,8 +153,7 @@ public abstract class AbstractUseDataProviderArgumentProvider<SOURCE_ANNOTATION 
             // TODO how to not require junit-jupiter-engine dependency and reuse already existing ExtensionRegistry?
             ExtensionRegistry extensionRegistry = createRegistryWithDefaultExtensions(
                     new DefaultJupiterConfiguration(emptyConfigurationParameters()));
-            Object data = executableInvoker.invoke(dataProviderMethod, context.getTestInstance().orElse(null), context,
-                    extensionRegistry, InvocationInterceptor::interceptTestFactoryMethod);
+            Object data = new DefaultExecutableInvoker(context, extensionRegistry).invoke(dataProviderMethod, context.getTestInstance().orElse(null));
             if (cacheDataProviderResult) {
                 store.put(dataProviderMethod, data);
             }

--- a/junit-jupiter-params/src/main/java/com/tngtech/junit/dataprovider/AbstractUseDataProviderArgumentProvider.java
+++ b/junit-jupiter-params/src/main/java/com/tngtech/junit/dataprovider/AbstractUseDataProviderArgumentProvider.java
@@ -21,7 +21,9 @@ import static org.junit.jupiter.engine.extension.MutableExtensionRegistry.create
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.TestInfo;
@@ -31,7 +33,7 @@ import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.engine.config.DefaultJupiterConfiguration;
-import org.junit.jupiter.engine.execution.ExecutableInvoker;
+import org.junit.jupiter.engine.execution.InterceptingExecutableInvoker;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.platform.engine.ConfigurationParameters;
@@ -52,7 +54,7 @@ import com.tngtech.junit.dataprovider.resolver.DataProviderResolverContext;
 public abstract class AbstractUseDataProviderArgumentProvider<SOURCE_ANNOTATION extends Annotation, DATAPROVIDER_ANNOTATION extends Annotation>
         extends AbstractDataProviderArgumentProvider<SOURCE_ANNOTATION> {
 
-    private static final ExecutableInvoker executableInvoker = new ExecutableInvoker();
+    private static final InterceptingExecutableInvoker executableInvoker = new InterceptingExecutableInvoker();
 
     protected static final Namespace NAMESPACE_USE_DATAPROVIDER = Namespace
             .create(AbstractUseDataProviderArgumentProvider.class, "dataCache");
@@ -184,6 +186,11 @@ public abstract class AbstractUseDataProviderArgumentProvider<SOURCE_ANNOTATION 
             @Override
             public Optional<String> get(String key) {
                 return Optional.empty();
+            }
+
+            @Override
+            public Set<String> keySet() {
+                return Collections.emptySet();
             }
         };
     }

--- a/junit-jupiter/pom.xml
+++ b/junit-jupiter/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.5.0</version>
+            <version>5.9.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/junit-jupiter/src/main/java/com/tngtech/junit/dataprovider/UseDataProviderInvocationContextProvider.java
+++ b/junit-jupiter/src/main/java/com/tngtech/junit/dataprovider/UseDataProviderInvocationContextProvider.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.*;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.engine.config.DefaultJupiterConfiguration;
-import org.junit.jupiter.engine.execution.InterceptingExecutableInvoker;
+import org.junit.jupiter.engine.execution.DefaultExecutableInvoker;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.engine.ConfigurationParameters;
 
@@ -52,8 +52,6 @@ import com.tngtech.junit.dataprovider.resolver.DataProviderResolverContext;
  */
 public abstract class UseDataProviderInvocationContextProvider<TEST_ANNOTATION extends Annotation, DATAPROVIDER_ANNOTATION extends Annotation>
         extends AbstractDataProviderInvocationContextProvider<TEST_ANNOTATION> {
-
-    private static final InterceptingExecutableInvoker executableInvoker = new InterceptingExecutableInvoker();
 
     protected static final Namespace NAMESPACE_USE_DATAPROVIDER = Namespace
             .create(UseDataProviderInvocationContextProvider.class, "dataCache");
@@ -175,8 +173,7 @@ public abstract class UseDataProviderInvocationContextProvider<TEST_ANNOTATION e
             // TODO how to not require junit-jupiter-engine dependency and reuse already existing ExtensionRegistry?
             ExtensionRegistry extensionRegistry = createRegistryWithDefaultExtensions(
                     new DefaultJupiterConfiguration(emptyConfigurationParameters()));
-            Object data = executableInvoker.invoke(dataProviderMethod, context.getTestInstance().orElse(null), context,
-                    extensionRegistry, InvocationInterceptor::interceptTestFactoryMethod);
+            Object data = new DefaultExecutableInvoker(context, extensionRegistry).invoke(dataProviderMethod, context.getTestInstance().orElse(null));
             if (cacheDataProviderResult) {
                 store.put(dataProviderMethod, data);
             }

--- a/junit-jupiter/src/main/java/com/tngtech/junit/dataprovider/UseDataProviderInvocationContextProvider.java
+++ b/junit-jupiter/src/main/java/com/tngtech/junit/dataprovider/UseDataProviderInvocationContextProvider.java
@@ -22,19 +22,18 @@ import static org.junit.jupiter.engine.extension.MutableExtensionRegistry.create
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.*;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
-import org.junit.jupiter.api.extension.InvocationInterceptor;
-import org.junit.jupiter.api.extension.ParameterResolutionException;
-import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.engine.config.DefaultJupiterConfiguration;
-import org.junit.jupiter.engine.execution.ExecutableInvoker;
+import org.junit.jupiter.engine.execution.InterceptingExecutableInvoker;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.engine.ConfigurationParameters;
 
@@ -54,7 +53,7 @@ import com.tngtech.junit.dataprovider.resolver.DataProviderResolverContext;
 public abstract class UseDataProviderInvocationContextProvider<TEST_ANNOTATION extends Annotation, DATAPROVIDER_ANNOTATION extends Annotation>
         extends AbstractDataProviderInvocationContextProvider<TEST_ANNOTATION> {
 
-    private static final ExecutableInvoker executableInvoker = new ExecutableInvoker();
+    private static final InterceptingExecutableInvoker executableInvoker = new InterceptingExecutableInvoker();
 
     protected static final Namespace NAMESPACE_USE_DATAPROVIDER = Namespace
             .create(UseDataProviderInvocationContextProvider.class, "dataCache");
@@ -206,6 +205,11 @@ public abstract class UseDataProviderInvocationContextProvider<TEST_ANNOTATION e
             @Override
             public Optional<String> get(String key) {
                 return Optional.empty();
+            }
+
+            @Override
+            public Set<String> keySet() {
+                return Collections.emptySet();
             }
         };
     }

--- a/junit-jupiter/src/main/java/com/tngtech/junit/dataprovider/UseDataProviderInvocationContextProvider.java
+++ b/junit-jupiter/src/main/java/com/tngtech/junit/dataprovider/UseDataProviderInvocationContextProvider.java
@@ -29,9 +29,11 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.engine.config.DefaultJupiterConfiguration;
 import org.junit.jupiter.engine.execution.DefaultExecutableInvoker;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;

--- a/junit-jupiter/src/main/java/com/tngtech/junit/dataprovider/UseDataProviderInvocationContextProvider.java
+++ b/junit-jupiter/src/main/java/com/tngtech/junit/dataprovider/UseDataProviderInvocationContextProvider.java
@@ -192,6 +192,7 @@ public abstract class UseDataProviderInvocationContextProvider<TEST_ANNOTATION e
 
     private ConfigurationParameters emptyConfigurationParameters() {
         return new ConfigurationParameters() {
+            @SuppressWarnings("deprecation")
             @Override
             public int size() {
                 return 0;


### PR DESCRIPTION
Signed-off-by: Jens Schulze <jens.schulze@commercetools.com>

## Overview

With version 5.9 of Junit Jupiter engine the ExecutableInvoker class became an interface.

Also the ConfigurationParameters got a new method `keySet` with 5.9.

It should be noted that the API annotations by JUnit are not correct. The `keySet` method is annotated as available since 1.9 but has been introduced with 5.9 too.

This change means that the minimum version for the dataprovider will be 5.9.0 for junit jupiter engine and parameters

Fixes #136 

---

I hereby agree to the terms of the [JUnit dataprovider Contributor License Agreement](https://github.com/tng/junit-dataprovider/blob/master/CONTRIBUTING.md#junit-dataprovider-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](https://github.com/TNG/junit-dataprovider/blob/master/core/src/main/java/com/tngtech/junit/dataprovider/Preconditions.java) are checked and documented in the method's Javadoc
- [ ] Change is covered by automated tests (unit and/or integration tests)
- [ ] [Build](https://travis-ci.org/TNG/junit-dataprovider) has passed
