### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -5,6 +5,8 @@ jobs:
   validation:
     name: "Gradle wrapper validation"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: gradle/actions/wrapper-validation@v3


### PR DESCRIPTION
Potential fix for [https://github.com/TNG/junit-dataprovider/security/code-scanning/4](https://github.com/TNG/junit-dataprovider/security/code-scanning/4)

In general, the fix is to add an explicit `permissions` block to restrict the `GITHUB_TOKEN` to the minimum needed for this workflow. For a Gradle wrapper validation workflow that only checks out code and runs a validation action, `contents: read` is sufficient.

The best fix here, without changing functionality, is to add a job-level `permissions` block under the `validation` job in `.github/workflows/gradle-wrapper-validation.yml`. This keeps the scope local to this job and does not affect other workflows. Concretely, in that file, under `jobs: validation:`, add:

```yaml
    permissions:
      contents: read
```

indented to align with `name:` and `runs-on:`. No additional imports, methods, or definitions are needed because this is just YAML configuration for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
