### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,6 +2,9 @@ name: Java CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/TNG/junit-dataprovider/security/code-scanning/3](https://github.com/TNG/junit-dataprovider/security/code-scanning/3)

To fix the problem, we need to add an explicit `permissions` block that grants only the minimal permissions required by this CI job. Since the job just checks out code, sets up Java/Gradle, and runs `./gradlew build`, it only needs read access to the repository contents. The recommended starting point from the warning is `contents: read`, which will override any broader org/repo defaults.

The best minimal change without altering existing functionality is to add a `permissions` stanza at the workflow root (top level), so it applies to all jobs in this workflow. Concretely, edit `.github/workflows/gradle.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block. This does not require any imports or additional methods; it is purely a configuration addition in the YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
